### PR TITLE
Fix supported version, fix typo/formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ also previously deployed at the Orain non-profit wiki farm before it went
 offline.
 
 Compared to the original version of the skin, this fork now supports MediaWiki
-versions 1.24 to 1.29 officially, with verified support for 1.30+ in the works.
+versions 1.24 to 1.28 officially, with verified support for 1.29+ in the works.
 This codebase will usually remain up-to-date against MediaWiki, and will drop
 support for older versions unconditionally once it becomes impractical to
 continue to support them.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This codebase will usually remain up-to-date against MediaWiki, and will drop
 support for older versions unconditionally once it becomes impractical to
 continue to support them.
 
-New features in this fork over `dantman/monaco-port` include:  
+New features in this fork over `dantman/monaco-port` include:
 
 * A new Widgets framework which cooperates with [Extension:Gadgets](https://www.mediawiki.org/wiki/Extension:Gadgets) to allow sidebar content to be defined through the MediaWiki frontend.
 * Special support for [Extension:FlaggedRevs](https://www.mediawiki.org/wiki/Extension:FlaggedRevs) and [Extension:MobileFrontend](https://www.mediawiki.org/wiki/Extension:MobileFrontend) when they are installed.
@@ -45,16 +45,16 @@ near the end of your LocalSettings.php to finish installation of the skin.
 
 You can also include the ExtendedBodyAttributes.php code if you wish to
 re-introduce the mainpage and loggedout classes that were in Wikia's version of
-Monaco, doing this will actually make these css classes available globally to
+Monaco, doing this will actually make these CSS classes available globally to
 all skins that are programmed using the MediaWiki 1.16 headElement code.
 
 Additionally you can install the ContentRightSidebar extension using:
 
-`require_once("$IP/skins/monaco/ContentRightSiebar.php");`
+`require_once("$IP/skins/monaco/ContentRightSidebar.php");`
 
 Doing so will provide you with a `<right-sidebar>...</right-sidebar>` tag which 
 will create right floated content in the page that will be moved into the right
-sidebar in monaco based skins. You can also use it with the args 
+sidebar in monaco based skins. You can also use it with the args:
 
 `<right-sidebar with-box="true" title="My Title">...</right-sidebar>`
 


### PR DESCRIPTION
[MW 1.29 removed](https://www.mediawiki.org/wiki/Release_notes/1.29#Other_changes_in_1.29) this method: "Revision::getText() (deprecated in 1.21) was removed."
It is used in Monaco.skin.php and MonacoSidebar.class.php, so the current skin is only supported up to MW 1.28.

When the code is updated to no longer use the method, the version can be incremented again.

Also applying a few readme fixes.