### PR TITLE
Replace use of removed method Revision::getText()

### DIFF
--- a/Monaco.skin.php
+++ b/Monaco.skin.php
@@ -281,7 +281,10 @@ class SkinMonaco extends SkinTemplate {
 	private function getLines($message_key) {
 		$revision = Revision::newFromTitle(Title::newFromText($message_key, NS_MEDIAWIKI));
 		if(is_object($revision)) {
-			if(trim($revision->getText()) != '') {
+			// replace $revision->getText(), removed in MW 1.29
+			$content = $revision->getContent();
+			$text = ContentHandler::getContentText($content);
+			if(trim($text) != '') {
 				$temp = MonacoSidebar::getMessageAsArray($message_key);
 				if(count($temp) > 0) {
 					wfDebugLog('monaco', sprintf('Get LOCAL %s, which contains %s lines', $message_key, count($temp)));
@@ -409,7 +412,9 @@ class SkinMonaco extends SkinTemplate {
 		global $wgParser, $wgMessageCache;
 		$revision = Revision::newFromTitle(Title::newFromText($name));
 		if(is_object($revision)) {
-			$text = $revision->getText();
+			// replace $revision->getText(), removed in MW 1.29
+			$content = $revision->getContent();
+			$text = ContentHandler::getContentText($content);
 			if(!empty($text)) {
 				$ret = $wgParser->transformMsg($text, $wgMessageCache->getParserOptions());
 				if($asArray) {

--- a/MonacoSidebar.class.php
+++ b/MonacoSidebar.class.php
@@ -135,7 +135,9 @@ class MonacoSidebar {
 		global $wgUser,  $wgParser, $wgMessageCache;
 		$revision = Revision::newFromTitle(Title::newFromText('User:'.$wgUser->getName().'/Monaco-sidebar'));
 		if(is_object($revision)) {
-			$text = $revision->getText();
+			// replace $revision->getText(), removed in MW 1.29
+			$content = $revision->getContent();
+			$text = ContentHandler::getContentText($content);
 			if(!empty($text)) {
 				$ret = explode("\n", $wgParser->transformMsg($text, $wgMessageCache->getParserOptions()));
 				return $ret;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ also previously deployed at the Orain non-profit wiki farm before it went
 offline.
 
 Compared to the original version of the skin, this fork now supports MediaWiki
-versions 1.24 to 1.28 officially, with verified support for 1.29+ in the works.
+versions 1.24 to 1.29 officially, with verified support for 1.30+ in the works.
 This codebase will usually remain up-to-date against MediaWiki, and will drop
 support for older versions unconditionally once it becomes impractical to
 continue to support them.


### PR DESCRIPTION
Applies the [substitute code](https://gitlab-replica-a.wikimedia.org/dancy-test-mw/core/-/blob/1.27.7/includes/Revision.php#L992) that existed until MW 1.27.

Increments supported versions to 1.29.